### PR TITLE
GH Action to zip sector

### DIFF
--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -2,7 +2,7 @@
 name: ZIP Sector
 on: 
   push:
-    branches: '**' #'main'
+    branches: 'main'
   release:
     types: [published]
 
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,7 +32,6 @@ jobs:
             ISRAEL.clr
             LLLL.isc
             Include/
-
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Action will run on:
- every push to main branch
- on release creation and be uploaded as part of the release
<img width="250" height="250" alt="image" src="https://github.com/user-attachments/assets/0656a25a-70cf-4d06-a6da-a0a0e17b9074" />
